### PR TITLE
Add missing includes in eme2.c and xts.c

### DIFF
--- a/eme2.c
+++ b/eme2.c
@@ -27,6 +27,7 @@
 
 #include "mode_hdr.h"
 #include "eme2.h"
+#include "gf_mulx.h"
 
 #define BLOCK_PWR2      4
 #define BLOCK_SIZE      (1 << BLOCK_PWR2)

--- a/gf_mulx.h
+++ b/gf_mulx.h
@@ -1,5 +1,5 @@
-#ifndef _GF_COMMON_H
-#define _GF_COMMON_H
+#ifndef _GF_MULX_H
+#define _GF_MULX_H
 
 #if defined(__cplusplus)
 extern "C"

--- a/xts.c
+++ b/xts.c
@@ -30,6 +30,7 @@
 
 #include "mode_hdr.h"
 #include "xts.h"
+#include "gf_mulx.h"
 
 UNIT_TYPEDEF(buf_unit, UNIT_BITS);
 BUFR_TYPEDEF(buf_type, UNIT_BITS, AES_BLOCK_SIZE);


### PR DESCRIPTION
Mea culpa: it looks like I forgot to add the relevant include directives in ```eme2.c``` and ```xts.c```.